### PR TITLE
Fix AddTodo import path

### DIFF
--- a/src/components/ToDo.jsx
+++ b/src/components/ToDo.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import AddTodo from "./AddTodo";
+import AddTodo from './AddToDo';
 import TodoList from './TodoList';
 
 const API_URL = 'https://backend-cuhi.onrender.com';


### PR DESCRIPTION
## Summary
- update import in `ToDo.jsx` to match `AddToDo.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Could not find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68402bb5c780832daf0843af47e7a6f2