### PR TITLE
Remove erasableSyntaxOnly

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -19,7 +19,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
+    "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -17,7 +17,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
+    "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },


### PR DESCRIPTION
## Summary
- remove `erasableSyntaxOnly` from tsconfigs
- use `exactOptionalPropertyTypes` for strict option

## Testing
- `npx tsc -b` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68402bb10e18832d87645d16f78d00a8