### PR TITLE
Add Jest and test for AddToDo

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  extensionsToTreatAsEsm: ['.ts', '.tsx', '.jsx'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: 'tsconfig.jest.json'
+    }
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts']
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.6",
@@ -28,6 +29,13 @@
     "tailwindcss": "^4.1.6",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.11",
+    "ts-jest": "^29.1.1",
+    "jest-environment-jsdom": "^29.7.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/user-event": "^14.4.3"
   }
 }

--- a/src/components/__tests__/AddToDo.test.tsx
+++ b/src/components/__tests__/AddToDo.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import AddTodo from '../AddToDo.jsx';
+
+test('calls onAddToDo and clears input fields after adding a todo', () => {
+  const onAddToDo = jest.fn();
+  render(<AddTodo onAddToDo={onAddToDo} />);
+
+  const [titleInput, dateInput, timeInput, locationInput] = screen.getAllByRole('textbox');
+  fireEvent.change(titleInput, { target: { value: 'Test task' } });
+  fireEvent.change(dateInput, { target: { value: '2025-06-05' } });
+  fireEvent.change(timeInput, { target: { value: '12:00' } });
+  fireEvent.change(locationInput, { target: { value: 'Home' } });
+
+  fireEvent.click(screen.getByRole('button', { name: /toevoegen/i }));
+
+  expect(onAddToDo).toHaveBeenCalledWith('Test task', '2025-06-05', '12:00', 'Home');
+  expect(titleInput).toHaveValue('');
+  expect(dateInput).toHaveValue('');
+  expect(timeInput).toHaveValue('');
+  expect(locationInput).toHaveValue('');
+});

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "jest.setup.ts"]
+}


### PR DESCRIPTION
## Summary
- set up Jest + React Testing Library
- add a simple jest-dom setup
- create tsconfig for tests
- add test verifying AddToDo calls onAddToDo and clears inputs

## Testing
- `npm test` *(fails: Cannot find module '/workspace/my-todo/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68402bb78cec832d8bcd102ae8c223c3